### PR TITLE
#50 - 엔티티 리팩토링

### DIFF
--- a/src/main/java/com/ansj/demo/domain/Article.java
+++ b/src/main/java/com/ansj/demo/domain/Article.java
@@ -59,11 +59,12 @@ public class Article extends AuditingFields {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Article article = (Article) o;
-        return id != null && id.equals(article.id);
+//        return id != null && id.equals(article.id);
+        return this.getId() != null && this.getId().equals(article.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/ansj/demo/domain/ArticleComment.java
+++ b/src/main/java/com/ansj/demo/domain/ArticleComment.java
@@ -54,11 +54,12 @@ public class ArticleComment extends AuditingFields{
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ArticleComment that = (ArticleComment) o;
-        return id != null && id.equals(that.id);
+//        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/ansj/demo/domain/UserAccount.java
+++ b/src/main/java/com/ansj/demo/domain/UserAccount.java
@@ -45,11 +45,12 @@ public class UserAccount extends AuditingFields {
         if (o == null || getClass() != o.getClass()) return false;
         UserAccount that = (UserAccount) o;
 //        return Objects.equals(id, that.id);
-        return userId != null && userId.equals(that.userId);
+//        return userId != null && userId.equals(that.userId);
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
엔티티 데이터는 하이버네이트 구현체가 만든 프록시 객체가를 이용하여 지연로딩을 할 수 있는데, 엔티티를 조회할 때필드에 직접 접근 id == null 인 상황이 있을 수 있고, 이러면 올바른 비교를 하지 못하게 된다. 그래서 getter를 사용하도록 수정했다.