### PR TITLE
#58 - 대댓글 도메인 설계

### DIFF
--- a/src/main/java/com/ansj/demo/domain/ArticleComment.java
+++ b/src/main/java/com/ansj/demo/domain/ArticleComment.java
@@ -11,7 +11,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 
 @Getter
@@ -23,13 +25,31 @@ import java.util.Objects;
 })
 @EntityListeners(AuditingEntityListener.class)
 @Entity
-public class ArticleComment extends AuditingFields{
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+public class ArticleComment extends AuditingFields {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter @ManyToOne(optional = false) private Article article; // 게시글(ID)
-    @Setter @ManyToOne(optional = false) @JoinColumn(name = "userId") private UserAccount userAccount;
-    @Setter @Column(nullable = false, length = 500) private String content; // 본문
+    @Setter
+    @ManyToOne(optional = false)
+    private Article article; // 게시글(ID)
+    @Setter
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "userId")
+    private UserAccount userAccount;
+
+    @Setter
+    @Column(updatable = false)
+    private Long parentCommentId; // 부모 댓글 ID
+
+    @ToString.Exclude
+    @OrderBy("createdAt ASC")
+    @OneToMany(mappedBy = "parentCommentId",cascade = CascadeType.ALL)
+    private Set<ArticleComment> childComments = new LinkedHashSet<>();
+
+    @Setter
+    @Column(nullable = false, length = 500)
+    private String content; // 본문
 
 //    @CreatedDate @Column(nullable = false) private LocalDateTime createdAt; // 생성일시
 //    @CreatedBy @Column(nullable = false, length = 100) private String createdBy; // 생성자
@@ -39,14 +59,20 @@ public class ArticleComment extends AuditingFields{
     protected ArticleComment() {
     }
 
-    private ArticleComment(Article article, UserAccount userAccount, String content) {
+    private ArticleComment(Article article, UserAccount userAccount, Long parentCommentId, String content) {
         this.article = article;
         this.userAccount = userAccount;
+        this.parentCommentId = parentCommentId;
         this.content = content;
     }
 
     public static ArticleComment of(Article article, UserAccount userAccount, String content) {
-        return new ArticleComment(article, userAccount, content);
+        return new ArticleComment(article, userAccount, null, content);
+    }
+
+    public void addChildComment(ArticleComment child) {
+        child.setParentCommentId(this.getId());
+        this.getChildComments().add(child);
     }
 
     @Override


### PR DESCRIPTION
대댓글 도메인 안에서 부모, 자식 관계를 설정하는 코드를 추가
자식 댓글의 컬렉션 변화가 쿼리에 반영되게끔
cascading 규칙을 모두 적용
이번엔 단방향 연관관계 설정을 사용해보기로 함.
따라서 부모 댓글은 엔티티가 아닌 `Long` id를 직접 표현
또한 자식 댓글을 추가할 수 있는 메소드 추가 제공